### PR TITLE
Make @types/react-router-dom a dependency instead of a devdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^16.9.35",
     "@types/react-dom": "^16.9.8",
     "@types/react-router": "^5.1.8",
+    "@types/react-router-dom": "^5.1.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
@@ -42,7 +43,6 @@
     ]
   },
   "devDependencies": {
-    "@types/react-router-dom": "^5.1.5",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "ts-jest": "^26.0.0"
   }


### PR DESCRIPTION
#### What's this PR do?
I changed @types/react-router-dom to a dependency rather than a devdependency to see if it would compile properly in order to deploy to Heroku. 

#### Where should the reviewer start?
package.json

#### How should this be manually tested?
By viewing the deployed site 

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Questions: